### PR TITLE
Fix Relative path of assets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ FetchContent_Declare(SFML
     SYSTEM)
 FetchContent_MakeAvailable(SFML)
 
+# Define o PROJECT_ROOT como variável global
+add_compile_definitions(PROJECT_ROOT="${CMAKE_SOURCE_DIR}")
+
 # Procura de forma recursiva os arquivos .cpp na pasta src e salva em sources
 file(GLOB_RECURSE sources CONFIGURE_DEPENDS src/*.cpp)
 

--- a/src/Ente.cpp
+++ b/src/Ente.cpp
@@ -47,7 +47,10 @@ sf::Sprite Ente::getSprite() const{
 }
 
 void Ente::setTextura(){
-    pTextura->loadFromFile("../assets/images/Rogue/rogue.png");
+    std::string imagePath = PROJECT_ROOT;
+    imagePath += "/assets/images/Rogue/rogue.png";
+    
+    pTextura->loadFromFile(imagePath);
 }
 void Ente::desenhar(){
     pTarget->draw(getSprite());

--- a/src/Ente.h
+++ b/src/Ente.h
@@ -3,6 +3,8 @@
 
 #include "Gerenciador_Grafico.h"
 
+#include <string>
+
 class Ente{
 protected:
     //Identificação única do Ente


### PR DESCRIPTION
Pelo CMakeLists.txt, adiciona uma variável global do projeto que armazena o caminho da raíz do projeto