### PR TITLE
Fix: Reset duplo do clock

### DIFF
--- a/src/Jogo.cpp
+++ b/src/Jogo.cpp
@@ -86,17 +86,12 @@ void Jogo::executar() {
 
 
     while (gerGrafico->getJanelaAberta()) {
-        float deltaTime = gerGrafico->reiniciarClock();
-        
-
         gerEventos->gerenciar(); // Gerencia os eventos
 
         gerColisoes->executar(); // Detecta as colisões
 
         gerGrafico->limpaJanela(); // Limpa a janela
-        jogador->atualizaTempoAnimacao(deltaTime);
-
- 
+        jogador->atualizaTempoAnimacao(gerGrafico->getDeltaTime());
 
         gerGrafico->getJanela()->setView(gerGrafico->getJanela()->getDefaultView());
         gerGrafico->getJanela()->draw(backgroundSprite);


### PR DESCRIPTION
Retira uma das chamadas de reset do clock do loop principal.
Substitui a variável deltaTime pelo método que retorna o atributo interno deltaTime do gerenciador gráfico.

Fixes #35